### PR TITLE
Use async_register instead of async_register_admin_service

### DIFF
--- a/custom_components/dahua_vto/__init__.py
+++ b/custom_components/dahua_vto/__init__.py
@@ -77,11 +77,11 @@ async def async_setup(hass: HomeAssistant, config: dict):
             raise HomeAssistantError("entity not found")
 
     hass.data.setdefault(DOMAIN, {})
-    hass.helpers.service.async_register_admin_service(
+    hass.services.async_register(
         DOMAIN, SERVICE_OPEN_DOOR, service_open_door,
         schema=SERVICE_OPEN_DOOR_SCHEMA
     )
-    hass.helpers.service.async_register_admin_service(
+    hass.services.async_register(
         DOMAIN, SERVICE_SEND_COMMAND, service_send_command,
         schema=SERVICE_SEND_COMMAND_SCHEMA
     )


### PR DESCRIPTION
With the use of async_register_admin_service, only administrator accounts can use these features. I bumped into this issue where non-admin users were unable to trigger door unlock.

This patch resolves that issue, but may not be the best way of doing it. If the use of async_register_admin_service was intentional, perhaps some way to allow non admin users access would be handy.